### PR TITLE
Fixing error that occurs when starting a site

### DIFF
--- a/craftbots/entities/site.py
+++ b/craftbots/entities/site.py
@@ -26,7 +26,7 @@ class Site:
         if self.building_type == Building.BUILDING_TASK:
             if task_id is None:
                 for task in self.world.tasks:
-                    if task.node == self.node and task.project is None:
+                    if task.node == self.node and task.linked_site is None:
                         task.set_project(self)
                         self.task = task
                         self.needed_resources = task.needed_resources


### PR DESCRIPTION
Error that I encountered:

File "...\craft-bots\craftbots\entities\site.py", line 29, in __init__
    if task.node == self.node and task.project is None:
AttributeError: 'Task' object has no attribute 'project'

I propose changing task.project to task.linked_site, this fixed the error for me.