### PR TITLE
Getting rid of cancelled terms for clarity

### DIFF
--- a/craftbots/entities/site.py
+++ b/craftbots/entities/site.py
@@ -144,7 +144,7 @@ class Site:
 
         :return: The maximum progress
         """
-        return self.world.building_config["build_effort"] * sum(self.needed_resources) * sum(self.deposited_resources) / sum(self.needed_resources)
+        return self.world.building_config["build_effort"] * sum(self.deposited_resources)
 
     def ignore_me(self):
         """


### PR DESCRIPTION
sum(self.needed_resources) cancels itself. It's easier to read this line with it removed.