### PR TITLE
Initialize simulation on start-up

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -169,6 +169,7 @@ class CraftBotsGUI:
         dpg.setup_dearpygui()
         dpg.show_viewport()
         # dpg.maximize_viewport()
+        self.reset_simulation(None, None)
 
         # main GUI loop
         log_length = 0


### PR DESCRIPTION
Resetting the simulation start-up avoids needing to hit the 'reset' button each time the GUI is started. There may be a better place to put this, but I'm not sure where it might go. This location works for me.